### PR TITLE
Fix: Various layout issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @imgly/idml-importer
 
+## 1.2.3
+
+### Patch Changes
+
+- Fixed rounded corners not being applied to image-containing rectangles in IDML files
+
 ## 1.2.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/idml-importer",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "module": "dist/browser.js",
   "types": "dist/browser.d.ts",
   "type": "module",

--- a/src/lib/idml-parser/index.ts
+++ b/src/lib/idml-parser/index.ts
@@ -438,8 +438,8 @@ export class IDMLParser {
             if (!hasImageFill) {
               // Fill needs to be applied after setting height and width, because gradient fills need the dimensions
               this.applyFill(block, element);
-              this.applyBorderRadius(block, element);
             }
+            this.applyBorderRadius(block, element);
             // If this element does not have a fill until now, we add a fill block but disable it.
             // This is necessary because the CESDK Editor requires a fill block to be present.
             if (


### PR DESCRIPTION
- Fixed border radius on image blocks by moving `applyBorderRadius` outside `if (!hasImageFill)` block